### PR TITLE
BUGFIX: baseline crashes if dump is NaN

### DIFF
--- a/GAS/gridregion.py
+++ b/GAS/gridregion.py
@@ -211,7 +211,7 @@ def griddata(pixPerBeam = 3.0,
         for spectrum in console.ProgressBar((s[1].data)):            #pre-processing
             specData = spectrum['DATA']
             #baseline fit
-            if doBaseline:
+            if doBaseline & np.all(np.isfinite(specData)):
                 specData = baselineSpectrum(specData,order=1,
                                             baselineIndex=baselineIndex)
 


### PR DESCRIPTION
It addresses #105, where system crashes if individual dump is contains NaNs. 
It now checks that the spectrum is valid before removing the baseline