### PR TITLE
BUGFIX: corrupted FITS file #55

### DIFF
--- a/GAS/gridregion.py
+++ b/GAS/gridregion.py
@@ -145,6 +145,14 @@ def griddata(pixPerBeam = 3.0,
     if len(filelist) == 0:
         warnings.warn('There are no FITS files to process in '+rootdir+'/'+region+'/'+dirname)
         return
+    # check that every file in the filelist is valid
+    # If not then remove it and send warning message
+    for file_i in filelist:
+        try:
+            fits.open(file_i)
+        except:
+            warnings.warn('file {0} is corrupted'.format(file_i))
+            filelist.remove(file_i)
     #pull a test structure
     s = fits.getdata(filelist[0])
 


### PR DESCRIPTION
Brute force attempt to check the presence of corrupted FITS files. I could not find a simple way to check the validity of the file. This BUGFIX loops over all files and if it fails in opening any of them then it removes it from the `filelist`