### PR TITLE
More functionality for stacking

### DIFF
--- a/GAS/gasBinning.py
+++ b/GAS/gasBinning.py
@@ -52,7 +52,8 @@ def BinByMask(DataCube, Mask = None, CentroidMap = None,
             AccumSpec[:,idx] = channelShift(DataCube[:,ThisY,ThisX].value,
                                             -DeltaChan[idx])
         AccumSpec = np.nanmean(AccumSpec,axis=1)
-    return AccumSpec
+        OffsetVelocity = DataCube.spectral_axis-CentroidValue
+    return AccumSpec,OffsetVelocity
 
 
 

--- a/GAS/gasBinning.py
+++ b/GAS/gasBinning.py
@@ -6,8 +6,8 @@ from spectral_cube import SpectralCube
 from GAS import voronoi_2d_binning as v2d
 
 
-def BinByMask(DataCube, Mask, CentroidMap = None,
-              CentroidAggregator = np.nanmean):
+def BinByMask(DataCube, Mask = None, CentroidMap = None,
+              CentroidAggregator = np.nanmean, x = None, y = None):
     """
     Bin a data cube by a label mask, aligning the data to a common centroid.  Returns an array.
 
@@ -34,7 +34,10 @@ def BinByMask(DataCube, Mask, CentroidMap = None,
     ChannelWidth = np.median(DataCube.spectral_axis-
                              np.roll(DataCube.spectral_axis,1))
     RawData = DataCube.unmasked_data[:].value
-    y,x= np.where(Mask)
+    if Mask:
+        y,x= np.where(Mask)
+    # Trap y,x not set HERE!
+
     AccumSpec = np.zeros(DataCube.shape[0])
     if CentroidMap is None:
         for ThisX,ThisY in zip(x,y):

--- a/GAS/gasBinning.py
+++ b/GAS/gasBinning.py
@@ -52,7 +52,7 @@ def BinByMask(DataCube, Mask = None, CentroidMap = None,
             AccumSpec[:,idx] = channelShift(DataCube[:,ThisY,ThisX].value,
                                             -DeltaChan[idx])
         AccumSpec = np.nanmean(AccumSpec,axis=1)
-        OffsetVelocity = DataCube.spectral_axis-CentroidValue
+        OffsetVelocity = DataCube.spectral_axis.value-CentroidValue
     return AccumSpec,OffsetVelocity
 
 


### PR DESCRIPTION
This provides another approach to stacking, returning a single spectrum representing the stack in a bin as opposed to populating the cube with the average stack.  This representation makes more sense for cases where we are binning by another physical parameter, e.g., Column Density.